### PR TITLE
feat: support for passing the amount as integer

### DIFF
--- a/Tests/Unit/OrderCaptureRequestTest.php
+++ b/Tests/Unit/OrderCaptureRequestTest.php
@@ -11,11 +11,23 @@ class OrderCaptureRequestTest extends TestCase
     /**
      * @return void
      */
-    public function testConstructor(): void
+    public function testConstructorWithFloatAmount(): void
     {
         $transactionId = '123456';
         $amount = 100.50;
         $orderCaptureRequest = new OrderCaptureRequest($transactionId, $amount);
+
+        $this->assertInstanceOf(OrderCaptureRequest::class, $orderCaptureRequest);
+    }
+
+    /**
+     * @return void
+     */
+    public function testConstructorWithIntAmount(): void
+    {
+        $transactionId = '123456';
+        $amountInCents = 10050;
+        $orderCaptureRequest = new OrderCaptureRequest($transactionId, $amountInCents);
 
         $this->assertInstanceOf(OrderCaptureRequest::class, $orderCaptureRequest);
     }
@@ -38,7 +50,7 @@ class OrderCaptureRequestTest extends TestCase
     /**
      * @return void
      */
-    public function testGetBodyParametersWithAmount(): void
+    public function testGetBodyParametersWithFloatAmount(): void
     {
         $transactionId = '123456';
         $amount = 150.75;
@@ -49,6 +61,22 @@ class OrderCaptureRequestTest extends TestCase
         $this->assertIsArray($bodyParameters);
         $this->assertArrayHasKey('amount', $bodyParameters);
         $this->assertSame((int)round($amount * 100), $bodyParameters['amount']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetBodyParametersWithIntAmount(): void
+    {
+        $transactionId = '123456';
+        $amountInCents = 15075;
+        $orderCaptureRequest = new OrderCaptureRequest($transactionId, $amountInCents);
+
+        $bodyParameters = $orderCaptureRequest->getBodyParameters();
+
+        $this->assertIsArray($bodyParameters);
+        $this->assertArrayHasKey('amount', $bodyParameters);
+        $this->assertSame($amountInCents, $bodyParameters['amount']);
     }
 
     /**
@@ -78,12 +106,35 @@ class OrderCaptureRequestTest extends TestCase
      * @throws \PHPUnit\Framework\MockObject\Exception
      * @throws \PayNL\Sdk\Exception\PayException
      */
-    public function testStartWithAmount(): void
+    public function testStartWithFloatAmount(): void
     {
         $transactionId = '123456';
         $amount = 200.00;
         $orderCaptureRequest = $this->getMockBuilder(OrderCaptureRequest::class)
             ->setConstructorArgs([$transactionId, $amount])
+            ->onlyMethods(['start'])
+            ->getMock();
+
+        $mockPayOrder = $this->createMock(PayOrder::class);
+
+        $orderCaptureRequest->method('start')->willReturn($mockPayOrder);
+
+        $result = $orderCaptureRequest->start();
+
+        $this->assertInstanceOf(PayOrder::class, $result);
+    }
+
+    /**
+     * @return void
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \PayNL\Sdk\Exception\PayException
+     */
+    public function testStartWithIntAmount(): void
+    {
+        $transactionId = '123456';
+        $amountInCents = 20000;
+        $orderCaptureRequest = $this->getMockBuilder(OrderCaptureRequest::class)
+            ->setConstructorArgs([$transactionId, $amountInCents])
             ->onlyMethods(['start'])
             ->getMock();
 

--- a/Tests/Unit/OrderCreateRequestTest.php
+++ b/Tests/Unit/OrderCreateRequestTest.php
@@ -64,6 +64,21 @@ class OrderCreateRequestTest extends TestCase
 
     /**
      * @return void
+     */
+    public function testSetAmountInCents(): void
+    {
+        $request = new OrderCreateRequest();
+        $request->setAmountInCents(12345);
+
+        $reflection = new \ReflectionClass($request);
+        $amountProperty = $reflection->getProperty('amount');
+        $amountProperty->setAccessible(true);
+
+        $this->assertEquals(12345, $amountProperty->getValue($request));
+    }
+
+    /**
+     * @return void
      * @throws \Exception
      */
     public function testSetReference(): void

--- a/src/Model/Request/OrderCaptureRequest.php
+++ b/src/Model/Request/OrderCaptureRequest.php
@@ -24,13 +24,17 @@ class OrderCaptureRequest extends RequestData
 
     /**
      * @param $transactionId
-     * @param float|null $amount
+     * @param int|float|null $amount Amount in cents (int) or whole units (float), e.g. 1234 or 12.34 
      */
-    public function __construct($transactionId, float $amount = null)
+    public function __construct($transactionId, float|int $amount = null)
     {
         $this->transactionId = $transactionId;
         if (!empty($amount)) {
-            $this->setAmount($amount);
+            if (is_int($amount)) {
+                $this->amount = $amount;
+            } else {
+                $this->setAmount($amount);
+            }
         }
 
         parent::__construct('OrderCapture', '/orders/%transactionId%/capture', RequestInterface::METHOD_PATCH);
@@ -84,6 +88,17 @@ class OrderCaptureRequest extends RequestData
     {
         $this->mode = 'amount';
         $this->amount = (int)round($amount * 100);
+        return $this;
+    }
+
+    /**
+     * @param float $amount Amount in cents.
+     * @return $this
+     */
+    public function setAmountInCents(int $amountInCents): self
+    {
+        $this->mode = 'amount';
+        $this->amount = amountInCents;
         return $this;
     }
 

--- a/src/Model/Request/OrderCreateRequest.php
+++ b/src/Model/Request/OrderCreateRequest.php
@@ -124,6 +124,16 @@ class OrderCreateRequest extends RequestData
     }
 
     /**
+     * @param float $amount Whole amount in cents.
+     * @return $this
+     */
+    public function setAmountInCents(int $amountInCents): self
+    {
+        $this->amount = $amountInCents;
+        return $this;
+    }
+
+    /**
      * @param string $currency
      * @return $this
      */

--- a/src/Model/Request/TransactionRefundRequest.php
+++ b/src/Model/Request/TransactionRefundRequest.php
@@ -28,14 +28,18 @@ class TransactionRefundRequest extends RequestData
 
     /**
      * @param $transactionId Pay's orderid. Use EX-####-####-#### or Pay's orderID.
-     * @param float|null $amount
+     * @param int|float|null $amount Amount in *cents* (int) or *whole units* (float), e.g. `1234` or `12.34`
      * @param string $currency
      */
-    public function __construct($transactionId, float $amount = null, string $currency = '')
+    public function __construct($transactionId, float|int $amount = null, string $currency = '')
     {
         $this->transactionId = $transactionId;
         if (!empty($amount)) {
-            $this->setAmount($amount);
+            if (is_int($amount)) {
+                $this->amount = $amount;
+            } else {
+                $this->setAmount($amount);
+            }
         }
         if (!empty($currency)) {
             $this->setCurrency($currency);
@@ -100,6 +104,16 @@ class TransactionRefundRequest extends RequestData
     public function setAmount(float $amount): self
     {
         $this->amount = (int)round($amount * 100);
+        return $this;
+    }
+
+    /**
+     * @param float $amount Amount in cents.
+     * @return $this
+     */
+    public function setAmountInCents(int $amountInCents): self
+    {
+        $this->amount = amountInCents;
         return $this;
     }
 


### PR DESCRIPTION
This change updates OrderCreateRequest, OrderCaptureRequest, and TransactionRefundRequest to support setting the amount as an integer value in cents, in addition to the existing float-based approach.

Why:
- Avoids potential floating-point rounding issues when callers already use integer cents
- Maintains backward compatibility for existing code passing float (whole unit) amounts
- Simplifies integrations by allowing each consumer to choose the most appropriate amount format