### PR TITLE
Allow Symfony serializer ^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "guzzlehttp/guzzle": "^7",
     "psr/container": "^2 || ^1",
     "psr/http-message": "^2 || ^1",
-    "symfony/serializer": "^6.4 || ^7.0",
+    "symfony/serializer": "^6.4 || ^7.0 || ^8.0",
     "doctrine/collections": "^2.2",
     "laminas/laminas-hydrator": "^4.5"
   },


### PR DESCRIPTION
I added ^8.0 to the version constraints for symfony/serializer.

Things I checked before push:
- Checked changes in the [changelog](https://github.com/symfony/serializer/blob/8.1/CHANGELOG.md)
- Ran PHPUnit
- Ran PHPStan

All checks where ok.

Please let me know if I can do anything else to get this merged.